### PR TITLE
Fix the incorrect error message that appears after the uploader initialization fails.

### DIFF
--- a/index.js
+++ b/index.js
@@ -466,9 +466,9 @@ const upload = async (key, domain, path, type, rpc, chainId) => {
     }
 
     const uploader = new Uploader(key, handler.providerUrl, chainId, handler.address);
-    const check = await uploader.init(type);
-    if (!check) {
-      console.log(`ERROR: The current network does not support this upload type, please switch to another type.  Type=${type}`);
+    const status = await uploader.init(type);
+    if (!status) {
+      console.log(`ERROR: Failed to initialize SDK!`);
       return;
     }
     const infoArr = await uploader.upload(path, syncPoolSize);

--- a/upload/Uploader.js
+++ b/upload/Uploader.js
@@ -76,27 +76,24 @@ class Uploader {
         this.#ethStorage = new EthStorage(rpc, pk, contractAddress);
     }
 
-    async supportBlob() {
+    async init(uploadType) {
         try {
             const fileContract = new ethers.Contract(this.#contractAddress, fileBlobAbi, this.#wallet);
-            return await fileContract.isSupportBlob();
+            const isSupportBlob = await fileContract.isSupportBlob();
+            if (uploadType) {
+                // check upload type
+                if (!isSupportBlob && uploadType === VERSION_BLOB) {
+                    console.log(`ERROR: The current network does not support this upload type, please switch to another type. Type=${uploadType}`);
+                    return false;
+                }
+                this.#uploadType = uploadType;
+            } else {
+                this.#uploadType = isSupportBlob ? VERSION_BLOB : VERSION_CALL_DATA;
+            }
+            return true;
         } catch (e) {
             return false;
         }
-    }
-
-    async init(uploadType) {
-        const isSupportBlob = await this.supportBlob();
-        // check upload type
-        if (uploadType) {
-            this.#uploadType = uploadType;
-            if (!isSupportBlob && uploadType === VERSION_BLOB) {
-                return false;
-            }
-        } else {
-            this.#uploadType = isSupportBlob ? VERSION_BLOB : VERSION_CALL_DATA;
-        }
-        return true;
     }
 
     async initNonce() {


### PR DESCRIPTION
When the initialization file upload type fails, an initialization failure prompt should be displayed instead of an error message indicating that the uploaded file type is incorrect.

Wrong message:
`
JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)

ERROR: The current network does not support this upload type, please switch to another type.  Type=2
`