### PR TITLE
fix nodejs version is too low

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,0 +1,15 @@
+function checkNodeVersion() {
+    const requiredVersion = 17;
+    const currentNodeVersion = parseInt(process.version.slice(1), 10);
+    if (currentNodeVersion < requiredVersion) {
+        console.error(`Error: Your Node.js version (${currentNodeVersion}) is not supported by this package. Please upgrade to Node.js version ${requiredVersion} or higher.`);
+        process.exit(1);
+    }
+}
+
+try {
+    checkNodeVersion();
+} catch (error) {
+    console.error('Error occurred while checking Node.js version:', error);
+    process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "ethfs-cli",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A tool to upload files easily to a filesystem smart contract following ERC-5018.",
   "main": "index.js",
   "scripts": {
+    "install": "node install.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
To fix the issue of being able to globally install ethfs-cli successfully even when the Node.js version is too low.