### PR TITLE
Fix: Updated gasPrice retrieval method

### DIFF
--- a/upload/Uploader.js
+++ b/upload/Uploader.js
@@ -200,7 +200,7 @@ class Uploader {
                 });
 
                 // Fetch the current gas price and increase it
-                const currentGasPrice = await this.#wallet.provider.getGasPrice();
+                const currentGasPrice = await this.#wallet.getGasPrice();
                 // Increase % if user requests it
                 let increasedGasPrice = currentGasPrice;
                 if (gasPriceIncreasePercentage !== 0){


### PR DESCRIPTION
## Issue
- "`this[#wallet].provider.getGasPrice` is not a function" error when using T1.

## Fix
- Changed `this.#wallet.provider.getGasPrice` to `this.#wallet.getGasPrice`.