### PR TITLE
-t supports text types and can set the number of concurrencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,16 @@ npx ethfs-cli upload -f <directory|file> -a <address> -p <private-key> -c [chain
 
 
 ## Command
-| Short Name | Full Name    | description                                                                |   
-|------------|--------------|----------------------------------------------------------------------------|
-| -p         | --privateKey | private key                                                                |
-| -a         | --address    | contract address / domain name                                             |
-| -f         | --file       | upload file path / name                                                    |
-| -c         | --chainId    | chain id                                                                   |
-| -r         | --rpc        | provider url                                                               |
-| -t         | --type       | file upload type:<br/>calldata: `1` or `calldata` <br/>blob: `2` or `blob` |
-| -g         | --gasIncPct  | gas price increase percentage                                              |
+| Short Name | Full Name        | description                                                                |   
+|------------|------------------|----------------------------------------------------------------------------|
+| -p         | --privateKey     | private key                                                                |
+| -a         | --address        | contract address / domain name                                             |
+| -f         | --file           | upload file path / name                                                    |
+| -c         | --chainId        | chain id                                                                   |
+| -r         | --rpc            | provider url                                                               |
+| -t         | --type           | file upload type:<br/>calldata: `1` or `calldata` <br/>blob: `2` or `blob` |
+| -g         | --gasIncPct      | gas price increase percentage                                              |
+| -s         | --threadPoolSize | number of threads for concurrent file uploads                              |
  <br/>
 
 
@@ -107,7 +108,7 @@ Upload files, you need to specify the upload type. The default type is blob:2.<b
 If you want to use name instead of FlatDirectory address, the name should be pointed to the FlatDirectory 
 address in advance. Click [here](https://docs.web3url.io/tutorials-on-ethstorage-early-testnet/bind-domain-names-to-your-flatdirectory) for details.
 ```
-ethfs-cli upload -f <address|domain> -a <address> -p <private-key> -t [upload-type] -c [chain-id] -r [rpc] -g [gas-price-increase-percentage]
+ethfs-cli upload -f <address|domain> -a <address> -p <private-key> -t [upload-type] -c [chain-id] -r [rpc] -g [gas-price-increase-percentage] -s [thread-pool-size]
 ```
 ##### Example
 ```
@@ -115,6 +116,7 @@ FlatDirectory address
   ethfs-cli upload -f index.html -a gor:0x1825...2388 -p 0x32... -t 1
   ethfs-cli upload -f index.html -a 0x1825...2388 -p 0x32... -c 11155111 -t 1
   ethfs-cli upload -f index.html -a 0x1825...2388 -p 0x32... -r https://rpc.xxx -t calldata -g 20
+  ethfs-cli upload -f index.html -a 0x1825...2388 -p 0x32... -r https://rpc.xxx -t calldata -s 12
 ens
   ethfs-cli upload -f dist -a eth:ens.eth -p 0x32... -r https://rpc.ankr.com/eth -t 2
   ethfs-cli upload -f dist -a eth:ens.eth -p 0x32... -r https://rpc.ankr.com/eth -t blob

--- a/README.md
+++ b/README.md
@@ -1,30 +1,40 @@
 # ethfs-cli
 
 ## Installation
-Globally:
+### Globally:
 ```bash
 npm install -g ethfs-cli
-ethfs-cli upload -f <directory|file> -a <address> -p <private-key> -r [rpc] -t [upload-type]
 ```
 
-Locally:
+Once installed, you can upload file or directory using:
+```
+ethfs-cli upload -f <directory|file> -a <address> -p <private-key> -c [chain-id] -t [upload-type]
+```
+
+### Locally:
 ```bash
 npm install ethfs-cli
-npx ethfs-cli upload -f <directory|file> -a <address> -p <private-key> -r [rpc] -t [upload-type]
+```
+
+After installation, use npx to run the command:
+```
+npx ethfs-cli upload -f <directory|file> -a <address> -p <private-key> -c [chain-id] -t [upload-type]
 ```
 <br/>
 
+
 ## Command
-| Short Name | Full Name                    | description                                                                |   
-|------------|------------------------------|----------------------------------------------------------------------------|
-| -p         | --privateKey                 | private key                                                                |
-| -a         | --address                    | contract address / domain name                                             |
-| -f         | --file                       | upload file path / name                                                    |
-| -c         | --chainId                    | chain id                                                                   |
-| -r         | --rpc                        | provider url                                                               |
-| -t         | --type                       | file upload type:<br/>calldata: `1` or `calldata` <br/>blob: `2` or `blob` |
-| -g         | --gasPriceIncreasePercentage | gas price increase percentage                                              |
+| Short Name | Full Name    | description                                                                |   
+|------------|--------------|----------------------------------------------------------------------------|
+| -p         | --privateKey | private key                                                                |
+| -a         | --address    | contract address / domain name                                             |
+| -f         | --file       | upload file path / name                                                    |
+| -c         | --chainId    | chain id                                                                   |
+| -r         | --rpc        | provider url                                                               |
+| -t         | --type       | file upload type:<br/>calldata: `1` or `calldata` <br/>blob: `2` or `blob` |
+| -g         | --gasIncPct  | gas price increase percentage                                              |
  <br/>
+
 
 ## Supported networks
 | Chain Name                 | Chain Short Name and Chain Id |
@@ -53,28 +63,25 @@ npx ethfs-cli upload -f <directory|file> -a <address> -p <private-key> -r [rpc] 
 | Harmony Testnet Shard 0    | hmy-b-s0 / 1666700000         |
 | Evmos                      | evmos / 9001                  | 
 | Evmos Testnet              | evmos-testnet / 9000          |
+| QuarkChain L2 Testnet      | esl2-t / 43069                |
  
 
 ## Usage
 ### Support EIP-3770 Address
 ```
-ethereum
+Ethereum
     eth:<name|address>
-
-... 
-
-galileo
-    w3q-g:<name|address>       
+Sepolia
+    sep:<name|address>
+...    
 ```
 ##### Example
 ```
-ethereum
+Ethereum
     eth:ens.eth
-
+Sepolia
+    sep:0x1825...2388
 ...
-
-galileo
-    w3q-g:0x1825...2388
 ```
 <br/>
 
@@ -82,114 +89,85 @@ galileo
 ### Create FlatDirectory Command
 Ethereum is the default network if it's not specified, otherwise, you should use "--chainId" to set it. RPC should also be specified if the network is an unlisted network.
 ```
-ethfs-cli create -p <privateKey>
-ethfs-cli create -p <privateKey> -c [chainId]
-ethfs-cli create -p <privateKey> -c [chainId] -r [rpc]
+ethfs-cli create -p <private-key> -c [chain-id] -r [rpc]
 
 // output: contract address 
 ```
 ##### Example
 ```
 ethfs-cli create -p 0x32...
-ethfs-cli create -p 0x32... -c 5
-ethfs-cli create -p 0x32... -c 1 -r https://rpc.ankr.com/eth
+ethfs-cli create -p 0x32... -c 11155111
+ethfs-cli create -p 0x32... -r https://rpc.ankr.com/eth
 ```
 <br/>
-
 
 
 ### Upload Command
 Upload files, you need to specify the upload type. The default type is blob:2.<br/>
 If you want to use name instead of FlatDirectory address, the name should be pointed to the FlatDirectory 
-address in advance. Click [here](https://docs.web3url.io/advanced-topics/bind-ens-name-to-a-chain-specific-address) for details.
+address in advance. Click [here](https://docs.web3url.io/tutorials-on-ethstorage-early-testnet/bind-domain-names-to-your-flatdirectory) for details.
 ```
-FlatDirectory address
-  ethfs-cli upload -f <directory|file> -a <address> -p <privateKey> -r [rpc] -t [uploadType] -g [gas-price-percentage]
-ens
-  ethfs-cli upload -f <directory|file> -a <name> -p <privateKey> -r [rpc] -t [uploadType] -g [gas-price-percentage]
-w3ns
-  ethfs-cli upload -f <directory|file> -a <name> -p <privateKey> -r [rpc] -t [uploadType] -g [gas-price-percentage]
+ethfs-cli upload -f <address|domain> -a <address> -p <private-key> -t [upload-type] -c [chain-id] -r [rpc] -g [gas-price-increase-percentage]
 ```
 ##### Example
 ```
 FlatDirectory address
-  ethfs-cli upload -f index.html -a gor:0x1825...2388 -p 0x32... -g 20
-  ethfs-cli upload -f index.html -a xxx:0x1825...2388 -p 0x32... -r https://rpc.xxx -t 1
-  ethfs-cli upload -f index.html -a xxx:0x1825...2388 -p 0x32... -r https://rpc.xxx -t calldata
+  ethfs-cli upload -f index.html -a gor:0x1825...2388 -p 0x32... -t 1
+  ethfs-cli upload -f index.html -a 0x1825...2388 -p 0x32... -c 11155111 -t 1
+  ethfs-cli upload -f index.html -a 0x1825...2388 -p 0x32... -r https://rpc.xxx -t calldata -g 20
 ens
   ethfs-cli upload -f dist -a eth:ens.eth -p 0x32... -r https://rpc.ankr.com/eth -t 2
   ethfs-cli upload -f dist -a eth:ens.eth -p 0x32... -r https://rpc.ankr.com/eth -t blob
-w3ns
-  ethfs-cli upload -f dist -a w3q-g:home.w3q -p 0x32... -t 2 -g 20
 ```
 <br/>
 
 
 ### Set FlatDirectory Default Entrance
 ```
-FlatDirectory address
-  ethfs-cli default -a <address> -f <fileName> -p <privateKey> -r [rpc]
-ens
-  ethfs-cli default -a <name> -f <fileName> -p <privateKey> -r [rpc]
-w3ns
-  ethfs-cli default -a <name> -f <fileName> -p <privateKey> -r [rpc]
+ethfs-cli default -a <address|domain> -f <file-name> -p <private-key> -c [chain-id] -r [rpc]
 ```
 ##### Example
 ```
 FlatDirectory address
-  ethfs-cli default -a gor:0x1825...2388 -f index.html -p 0x32...
-  ethfs-cli default -a xxx:0x1825...2388 -f index.html -p 0x32... -r https://rpc.xxx
+  ethfs-cli default -a sep:0x1825...2388 -f index.html -p 0x32...
+  ethfs-cli default -a 0x1825...2388 -f index.html -p 0x32... -c 11155111
+  ethfs-cli default -a 0x1825...2388 -f index.html -p 0x32... -r https://rpc.xxx
 ens
   ethfs-cli default -a eth:ens.eth -f index.html -p 0x32... -r https://rpc.ankr.com/eth
-w3ns
-  ethfs-cli default -a w3q-g:home.w3q -f index.html -p 0x32...  -r https://rpc.ankr.com/eth
-```
-<br/>
-
-
-
-### Remove File
-```
-FlatDirectory address
-  ethfs-cli remove -a <address> -f <fileName> -p <privateKey> -r [rpc]
-ens
-  ethfs-cli remove -a <name> -f <fileName> -p <privateKey> -r [rpc]
-w3ns
-  ethfs-cli remove -a <name> -f <fileName> -p <privateKey> -r [rpc]
-```
-##### Example
-```
-FlatDirectory address
-  ethfs-cli remove -a gor:0x1825...2388 -f index.html -p 0x32...
-  ethfs-cli remove -a xxx:0x1825...2388 -f index.html -p 0x32... -r https://rpc.xxx
-ens
-  ethfs-cli remove -a eth:ens.eth -f src/home.vue -p 0x32... -r https://rpc.ankr.com/eth
-w3ns
-  ethfs-cli remove -a w3q-g:home.w3q -f src/home.vue -p 0x32... -r https://rpc.ankr.com/eth
 ```
 <br/>
 
 
 ### Download File
 ```
-FlatDirectory address
-  ethfs-cli download -a <address> -f <fileName> -r [rpc]
-ens
-  ethfs-cli download -a <name> -f <fileName> -r [rpc]
-w3ns
-  ethfs-cli download --address <name> --file <fileName> --rpc [rpc]
+ethfs-cli download -a <address|domain> -f <fileName> -c [chain-id] -r [rpc]
 ```
 ##### Example
 ```
 FlatDirectory address
-    npx ethfs-cli download -a gor:0x1825...2388 -f index.html
-    npx ethfs-cli download -a xxx:0x1825...2388 -f index.html -r https://rpc.xxx
+  ethfs-cli download -a sep:0x1825...2388 -f index.html
+  ethfs-cli download -a 0x1825...2388 -f index.html -c 11155111
+  ethfs-cli download -a 0x1825...2388 -f index.html -r https://rpc.xxx
 ens
-    npx ethfs-cli download -a eth:ens.eth -f home.vue
-w3ns
-    npx ethfs-cli download --address w3q-g:home.w3q --file home.vue --rpc https://rpc.xxx
+  ethfs-cli download -a eth:ens.eth -f home.vue
+```
+<br/>
+
+
+### Remove File
+```
+ethfs-cli remove -a <address|domain> -f <file-name> -p <private-key> -r [rpc] -c [chain-id]
+```
+##### Example
+```
+FlatDirectory address
+  ethfs-cli remove -a sep:0x1825...2388 -f index.html -p 0x32...
+  ethfs-cli remove -a 0x1825...2388 -f index.html -p 0x32... -c 11155111
+  ethfs-cli remove -a 0x1825...2388 -f index.html -p 0x32... -r https://rpc.xxx
+ens
+  ethfs-cli remove -a eth:ens.eth -f home.vue -p 0x32...
 ```
 <br/>
 
 ### Repo
-[Github Repo](https://github.com/QuarkChain/ethfs-cli)
+[Github Repo](https://github.com/ethstorage/ethfs-cli/)

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ npx ethfs-cli upload -f <directory|file> -a <address> -p <private-key> -r [rpc] 
 <br/>
 
 ## Command
-| Short Name | Full Name                    | description                                |   
-|------------|------------------------------|--------------------------------------------|
-| -p         | --privateKey                 | private key                                |
-| -a         | --address                    | contract address / domain name             |
-| -f         | --file                       | upload file path / name                    |
-| -c         | --chainId                    | chain id                                   |
-| -r         | --rpc                        | provider url                               |
-| -t         | --type                       | file save type<br/>on chain: 1<br/>blob: 2 |
-| -g         | --gasPriceIncreasePercentage | gas price increase percentage              |
+| Short Name | Full Name                    | description                                                                |   
+|------------|------------------------------|----------------------------------------------------------------------------|
+| -p         | --privateKey                 | private key                                                                |
+| -a         | --address                    | contract address / domain name                                             |
+| -f         | --file                       | upload file path / name                                                    |
+| -c         | --chainId                    | chain id                                                                   |
+| -r         | --rpc                        | provider url                                                               |
+| -t         | --type                       | file upload type:<br/>calldata: `1` or `calldata` <br/>blob: `2` or `blob` |
+| -g         | --gasPriceIncreasePercentage | gas price increase percentage                                              |
  <br/>
 
 ## Supported networks
@@ -115,8 +115,10 @@ w3ns
 FlatDirectory address
   ethfs-cli upload -f index.html -a gor:0x1825...2388 -p 0x32... -g 20
   ethfs-cli upload -f index.html -a xxx:0x1825...2388 -p 0x32... -r https://rpc.xxx -t 1
+  ethfs-cli upload -f index.html -a xxx:0x1825...2388 -p 0x32... -r https://rpc.xxx -t calldata
 ens
-  ethfs-cli upload -f dist -a eth:ens.eth -p 0x32... -r https://rpc.ankr.com/eth -t 2 -g 20
+  ethfs-cli upload -f dist -a eth:ens.eth -p 0x32... -r https://rpc.ankr.com/eth -t 2
+  ethfs-cli upload -f dist -a eth:ens.eth -p 0x32... -r https://rpc.ankr.com/eth -t blob
 w3ns
   ethfs-cli upload -f dist -a w3q-g:home.w3q -p 0x32... -t 2 -g 20
 ```

--- a/cli.js
+++ b/cli.js
@@ -83,7 +83,7 @@ program
     .option('-t, --type [type]', 'uploader type')
     .option('-c, --chainId [chainId]', 'chain id')
     .option('-r, --rpc [rpc]', 'provider url')
-    .option('-g, --gasPriceIncreasePercentage [gasPriceIncreasePercentage]', 'gas price increase percentage')
+    .option('-g, --gasIncPct [gasIncPct]', 'gas price increase percentage')
     .action(() => {
         const opts = program.opts();
         upload(opts.privateKey, opts.address, opts.file, opts.type, opts.rpc, opts.chainId, opts.gasPriceIncreasePercentage);

--- a/cli.js
+++ b/cli.js
@@ -84,9 +84,10 @@ program
     .option('-c, --chainId [chainId]', 'chain id')
     .option('-r, --rpc [rpc]', 'provider url')
     .option('-g, --gasIncPct [gasIncPct]', 'gas price increase percentage')
+    .option('-s, --threadPoolSize [threadPoolSize]', 'thread pool size')
     .action(() => {
         const opts = program.opts();
-        upload(opts.privateKey, opts.address, opts.file, opts.type, opts.rpc, opts.chainId, opts.gasPriceIncreasePercentage);
+        upload(opts.privateKey, opts.address, opts.file, opts.type, opts.rpc, opts.chainId, opts.gasIncPct, opts.threadPoolSize);
     });
 
 program.parse(process.argv);

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,9 @@ const {
   PROVIDER_URLS,
   ETH_STORAGE_RPC,
   ETHEREUM_CHAIN_ID,
-  FlatDirectoryAbi
+  FlatDirectoryAbi,
+  TYPE_CALLDATA,
+  TYPE_BLOB
 } = require('./params');
 const {
   isPrivateKey,
@@ -216,9 +218,15 @@ const estimateAndUpload = async (key, domain, path, type, rpc, chainId, gasPrice
     console.error(error(`ERROR: The file or folder does not exist!`), path);
     return;
   }
-  if (type && Number(type) !== UPLOAD_TYPE_CALLDATA && Number(type) !== UPLOAD_TYPE_BLOB) {
-    console.error(error(`ERROR: invalid upload type!`));
-    return;
+  if (type) {
+    if(type === TYPE_CALLDATA) {
+      type = UPLOAD_TYPE_CALLDATA;
+    } else if(type === TYPE_BLOB) {
+      type = UPLOAD_TYPE_BLOB;
+    } else if (Number(type) !== UPLOAD_TYPE_CALLDATA && Number(type) !== UPLOAD_TYPE_BLOB) {
+      console.error(error(`ERROR: invalid upload type!`));
+      return;
+    }
   }
 
   const handler = await getWebHandler(domain, rpc, chainId, CHAIN_ID_DEFAULT);

--- a/src/index.js
+++ b/src/index.js
@@ -255,6 +255,7 @@ const estimateAndUpload = async (key, domain, path, type, rpc, chainId, gasIncPc
     // upload
     await upload(uploader, path, gasIncPct, threadPoolSize);
   }
+  process.exit(0);
 }
 
 const answer = async (text) => {

--- a/src/index.js
+++ b/src/index.js
@@ -201,7 +201,7 @@ const download = async (domain, fileName, rpc, chainId) => {
   }
 }
 
-const estimateAndUpload = async (key, domain, path, type, rpc, chainId, gasPriceIncreasePercentage) => {
+const estimateAndUpload = async (key, domain, path, type, rpc, chainId, gasIncPct, threadPoolSize) => {
   if (!isPrivateKey(key)) {
     console.error(error(`ERROR: invalid private key!`));
     return;
@@ -245,15 +245,15 @@ const estimateAndUpload = async (key, domain, path, type, rpc, chainId, gasPrice
   let status = await answer(`Estimate gas cost?`);
   if (status) {
     // get cost
-    await estimateCost(uploader, path, gasPriceIncreasePercentage);
+    await estimateCost(uploader, path, gasIncPct, threadPoolSize);
     status = await answer(`Continue?`);
     if (status) {
       // upload
-      await upload(uploader, path, gasPriceIncreasePercentage);
+      await upload(uploader, path, gasIncPct, threadPoolSize);
     }
   } else {
     // upload
-    await upload(uploader, path, gasPriceIncreasePercentage);
+    await upload(uploader, path, gasIncPct, threadPoolSize);
   }
 }
 
@@ -266,10 +266,10 @@ const answer = async (text) => {
   return answer;
 }
 
-const estimateCost = async (uploader, path, gasPriceIncreasePercentage) => {
+const estimateCost = async (uploader, path, gasIncPct, threadPoolSize) => {
   const spin = ora('Start estimating cost').start();
   try {
-    const cost = await uploader.estimateCost(spin, path, gasPriceIncreasePercentage);
+    const cost = await uploader.estimateCost(spin, path, gasIncPct, threadPoolSize);
     spin.succeed('Estimating cost progress: 100%');
 
     console.log();
@@ -287,9 +287,9 @@ const estimateCost = async (uploader, path, gasPriceIncreasePercentage) => {
   }
 }
 
-const upload = async (uploader, path, gasPriceIncreasePercentage) => {
+const upload = async (uploader, path, gasIncPct, threadPoolSize) => {
   console.log();
-  const infoArr = await uploader.upload(path, gasPriceIncreasePercentage);
+  const infoArr = await uploader.upload(path, gasIncPct, threadPoolSize);
   console.log();
   let totalStorageCost = 0n, totalChunkCount = 0, totalDataSize = 0;
   for (const file of infoArr) {

--- a/src/params/constants.js
+++ b/src/params/constants.js
@@ -127,8 +127,8 @@ const ETH_STORAGE_RPC = {
     [QUARKCHAIN_L2_TESTNET_CHAIN_ID]: 'http://65.109.115.36:9540',
 }
 
-const VERSION_CALL_DATA = '1';
-const VERSION_BLOB = '2';
+const TYPE_CALLDATA = 'calldata';
+const TYPE_BLOB = 'blob';
 
 module.exports = {
     NETWORK_MAPPING,
@@ -141,6 +141,6 @@ module.exports = {
     ARBITRUM_NOVE_CHAIN_ID,
     ETHEREUM_CHAIN_ID,
 
-    VERSION_CALL_DATA,
-    VERSION_BLOB
+    TYPE_CALLDATA,
+    TYPE_BLOB
 }

--- a/src/params/constants.js
+++ b/src/params/constants.js
@@ -130,6 +130,8 @@ const ETH_STORAGE_RPC = {
 const TYPE_CALLDATA = 'calldata';
 const TYPE_BLOB = 'blob';
 
+const DEFAULT_THREAD_POOL_SIZE = 6;
+
 module.exports = {
     NETWORK_MAPPING,
     PROVIDER_URLS,
@@ -142,5 +144,7 @@ module.exports = {
     ETHEREUM_CHAIN_ID,
 
     TYPE_CALLDATA,
-    TYPE_BLOB
+    TYPE_BLOB,
+
+    DEFAULT_THREAD_POOL_SIZE
 }

--- a/src/utils/uploader.js
+++ b/src/utils/uploader.js
@@ -8,7 +8,8 @@ const {
 const {NodeFile} = require("ethstorage-sdk/file");
 
 const {
-    FlatDirectoryAbi
+    FlatDirectoryAbi,
+    DEFAULT_THREAD_POOL_SIZE
 } = require('../params');
 const {
     recursiveFiles
@@ -81,16 +82,16 @@ class Uploader {
     }
 
     // estimate cost
-    async estimateCost(spin, path, gasPriceIncreasePercentage) {
+    async estimateCost(spin, path, gasIncPct, threadPoolSize) {
         let totalFileCount = 0;
         let totalStorageCost = 0n;
         let totalGasCost = 0n;
 
-        const syncPoolSize = 6;
+        const syncPoolSize = threadPoolSize || DEFAULT_THREAD_POOL_SIZE;
         const files = recursiveFiles(path, '');
         return new Promise((resolve, reject) => {
             from(files)
-                .pipe(mergeMap(info => this.#estimate(info, gasPriceIncreasePercentage), syncPoolSize))
+                .pipe(mergeMap(info => this.#estimate(info, gasIncPct), syncPoolSize))
                 .subscribe({
                     next: (cost) => {
                         totalFileCount++;
@@ -110,7 +111,7 @@ class Uploader {
         });
     }
 
-    async #estimate(fileInfo, gasPriceIncreasePercentage) {
+    async #estimate(fileInfo, gasIncPct) {
         try {
             const {path, name} = fileInfo;
             const file = new NodeFile(path);
@@ -118,7 +119,7 @@ class Uploader {
                 key: name,
                 content: file,
                 type: this.#uploadType,
-                gasIncPct: gasPriceIncreasePercentage
+                gasIncPct: gasIncPct
             });
             return {
                 totalStorageCost: cost.storageCost, totalGasCost: cost.gasCost
@@ -130,12 +131,12 @@ class Uploader {
 
 
     // upload
-    async upload(path, gasPriceIncreasePercentage) {
-        const syncPoolSize = 6;
+    async upload(path, gasIncPct, threadPoolSize) {
+        const syncPoolSize = threadPoolSize || DEFAULT_THREAD_POOL_SIZE;
         const results = [];
         return new Promise((resolve, reject) => {
             from(recursiveFiles(path, ''))
-                .pipe(mergeMap(info => this.#upload(info, gasPriceIncreasePercentage), syncPoolSize))
+                .pipe(mergeMap(info => this.#upload(info, gasIncPct), syncPoolSize))
                 .subscribe({
                     next: (info) => { results.push(info); },
                     error: (error) => { reject(error); },
@@ -144,7 +145,7 @@ class Uploader {
         });
     }
 
-    async #upload(fileInfo, gasPriceIncreasePercentage) {
+    async #upload(fileInfo, gasIncPct) {
         const {path, name} = fileInfo;
 
         let totalChunkCount = 0;
@@ -179,7 +180,7 @@ class Uploader {
             key: name,
             content: file,
             type: this.#uploadType,
-            gasIncPct: gasPriceIncreasePercentage,
+            gasIncPct: gasIncPct,
             callback: callback
         });
         return {

--- a/src/utils/uploader.js
+++ b/src/utils/uploader.js
@@ -95,8 +95,8 @@ class Uploader {
                 .subscribe({
                     next: (cost) => {
                         totalFileCount++;
-                        totalStorageCost += cost.totalStorageCost;
-                        totalGasCost += cost.totalGasCost;
+                        totalStorageCost += cost.storageCost;
+                        totalGasCost += cost.gasCost;
                         spin.text = `Estimating cost progress: ${Math.ceil(totalFileCount / files.length * 100)}%`;
                     },
                     error: (error) => { reject(error) },
@@ -115,15 +115,12 @@ class Uploader {
         try {
             const {path, name} = fileInfo;
             const file = new NodeFile(path);
-            const cost = await this.#flatDirectory.estimateCost({
+            return await this.#flatDirectory.estimateCost({
                 key: name,
                 content: file,
                 type: this.#uploadType,
                 gasIncPct: gasIncPct
             });
-            return {
-                totalStorageCost: cost.storageCost, totalGasCost: cost.gasCost
-            }
         } catch (e) {
             throw new UploadError(e.message, fileInfo.name);
         }


### PR DESCRIPTION
Change
1. The --type parameter supports string `calldata` and `blob` in addition to `1` and `2`.
2. `Upload` adds a new parameter to specify the number of concurrent uploads.
3. Update Readme.



Local test:

1. `git clone https://github.com/ethstorage/ethfs-cli.git`
2. `git checkout -b new origin/type`
3. `yarn install`
4. `npm link`

Test case:

On a chain that supports Blob:

1. Create a contract.
2. Set default file
3. Use calldata to upload file.
4. Use blob to upload file.
5. Use calldata to upload files in a folder
6. Use blob to upload files in a folder
7. After uploading part of the calldata or blob, terminate the upload task and restart uploading again to test the speed of comparing the uploaded files.
8. Download file.
9. If all functions are normal, the test passes.

On a chain that does not support Blobs.

1. Create a contract.
2. Set default file
3. Use calldata to upload file.
4. Use calldata to upload the folder
5. After uploading some files, terminate the upload task and restart uploading again.
6. Download file.
7. If all functions are normal, the test passes.