### PR TITLE
Ensure Proper Cleanup by Calling close() After Task Completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea/
 /test.js
 /node_modules/
+/.env

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "colors-cli": "^1.0.33",
     "commander": "^11.1.0",
+    "dotenv": "^16.4.7",
     "eth-ens-namehash": "^2.0.8",
     "ethers": "^6.13.1",
     "ethstorage-sdk": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "commander": "^11.1.0",
     "eth-ens-namehash": "^2.0.8",
     "ethers": "^6.13.1",
-    "ethstorage-sdk": "^2.1.5",
+    "ethstorage-sdk": "^3.0.0",
     "js-sha3": "^0.8.0",
     "ora": "^5.4.1",
     "rxjs": "^7.8.1"

--- a/src/index.js
+++ b/src/index.js
@@ -159,16 +159,19 @@ const download = async (domain, fileName, rpc, chainId) => {
     if (!fd) {
       return;
     }
+    let success = true;
     await fd.download(fileName, {
       onProgress: (progress, count, chunk) => {
         fs.appendFileSync(savePath, chunk);
+        Logger.log(`Download: progress is ${progress} / ${count}`);
       },
       onFail: (e) => {
+        success = false;
         fs.unlink(savePath, () => {});
         Logger.error(`Download failed for file ${fileName}: ${e.message}`);
       },
       onFinish: () => {
-        Logger.success(`File downloaded successfully: ${savePath}`);
+        if (success) Logger.success(`File downloaded successfully: ${savePath}`);
       }
     });
   } else {
@@ -322,7 +325,8 @@ const upload = async (uploader, path, gasIncPct, threadPoolSize) => {
     Logger.success(`Total storage cost: ${ethers.formatEther(totalStorageCost)} ETH`);
   } catch (e) {
     const length = e.message.length;
-    Logger.error(`Execution failed. Please check the parameters and try again. info=${length > 500 ? (e.message.substring(0, 245) + " ... " + e.message.substring(length - 245, length)) : e.message}`);
+    Logger.error(length > 500 ? (e.message.substring(0, 245) + " ... " + e.message.substring(length - 245, length)) : e.message);
+    Logger.error(`Execution failed. Please check the error message and try again after making necessary adjustments.`);
   }
 };
 // **** internal function ****

--- a/src/index.js
+++ b/src/index.js
@@ -159,19 +159,17 @@ const download = async (domain, fileName, rpc, chainId) => {
     if (!fd) {
       return;
     }
-    let success = true;
     await fd.download(fileName, {
       onProgress: (progress, count, chunk) => {
         fs.appendFileSync(savePath, chunk);
         Logger.log(`Download: progress is ${progress} / ${count}`);
       },
       onFail: (e) => {
-        success = false;
         fs.unlink(savePath, () => {});
         Logger.error(`Download failed for file ${fileName}: ${e.message}`);
       },
       onFinish: () => {
-        if (success) Logger.success(`File downloaded successfully: ${savePath}`);
+         Logger.success(`File downloaded successfully: ${savePath}`);
       }
     });
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const ora = require("ora");
 const readline = require('readline');
-const { FlatDirectory, UploadType} = require("ethstorage-sdk");
+const { FlatDirectory, UploadType } = require("ethstorage-sdk");
 const { ethers } = require("ethers");
 const {
   PROVIDER_URLS,
@@ -16,7 +16,6 @@ const {
 } = require('./params');
 const {
   isPrivateKey,
-  checkBalance,
   getChainIdByRpc,
   getWebHandler,
   Uploader,
@@ -63,9 +62,13 @@ const createDirectory = async (key, chainId, rpc) => {
     rpc: providerUrl,
     privateKey: key,
   });
-  const address = await fd.deploy();
-  if (address) {
-    Logger.success("Deployment successful.");
+  try {
+    const address = await fd.deploy();
+    if (address) {
+      Logger.success("Deployment successful.");
+    }
+  } finally {
+    await safeClose(fd)
   }
 };
 
@@ -86,9 +89,13 @@ const setDefault = async (key, domain, filename, rpc, chainId) => {
     if (!fd) {
       return;
     }
-    const status = await fd.setDefault(filename);
-    if (status) {
-      Logger.success("Default file set successfully.");
+    try {
+      const status = await fd.setDefault(filename);
+      if (status) {
+        Logger.success("Default file set successfully.");
+      }
+    } finally {
+      await safeClose(fd)
     }
   } else {
     Logger.error(`Domain ${domain} does not exist.`);
@@ -112,24 +119,21 @@ const remove = async (key, domain, fileName, rpc, chainId) => {
   const handler = await getWebHandler(domain, rpc, chainId, CHAIN_ID_DEFAULT);
   if (handler?.providerUrl && parseInt(handler?.address) > 0) {
     const { providerUrl, address } = handler;
-    Logger.info(`Removing file: ${fileName}`);
-    const provider = new ethers.JsonRpcProvider(providerUrl);
-    const wallet = new ethers.Wallet(key, provider);
-    const prevInfo = await checkBalance(provider, address, wallet.address);
 
+    Logger.info(`Removing file: ${fileName}`);
     const fd = await createSDK(providerUrl, key, address);
     if (!fd) {
       return;
     }
-    const status = await fd.remove(fileName);
-    if (status) {
-      Logger.success("File removed successfully.");
-    }
 
-    const info = await checkBalance(provider, address, wallet.address);
-    Logger.info(`Domain balance: ${info.domainBalance}`);
-    Logger.info(`Account balance: ${info.accountBalance}`);
-    Logger.info(`Balance change: ${prevInfo.accountBalance - info.accountBalance}`);
+    try {
+      const status = await fd.remove(fileName);
+      if (status) {
+        Logger.success("File removed successfully.");
+      }
+    } finally {
+      await safeClose(fd)
+    }
   } else {
     Logger.error(`Domain ${domain} does not exist.`);
   }
@@ -159,19 +163,25 @@ const download = async (domain, fileName, rpc, chainId) => {
     if (!fd) {
       return;
     }
-    await fd.download(fileName, {
-      onProgress: (progress, count, chunk) => {
-        fs.appendFileSync(savePath, chunk);
-        Logger.log(`Download: progress is ${progress} / ${count}`);
-      },
-      onFail: (e) => {
-        fs.unlink(savePath, () => {});
-        Logger.error(`Download failed for file ${fileName}: ${e.message}`);
-      },
-      onFinish: () => {
-         Logger.success(`File downloaded successfully: ${savePath}`);
-      }
-    });
+
+    try {
+      await fd.download(fileName, {
+        onProgress: (progress, count, chunk) => {
+          fs.appendFileSync(savePath, chunk);
+          Logger.log(`Download: progress is ${progress} / ${count}`);
+        },
+        onFail: (e) => {
+          fs.unlink(savePath, () => {
+          });
+          Logger.error(`Download failed for file ${fileName}: ${e.message}`);
+        },
+        onFinish: () => {
+          Logger.success(`File downloaded successfully: ${savePath}`);
+        }
+      });
+    } finally {
+      await safeClose(fd)
+    }
   } else {
     Logger.error(`Domain ${domain} does not exist.`);
   }
@@ -235,6 +245,8 @@ const estimateAndUpload = async (key, domain, path, type, rpc, chainId, gasIncPc
       // upload
       Logger.log('');
       await upload(uploader, path, gasIncPct, threadPoolSize);
+    } else {
+      await safeClose(uploader);
     }
   } else {
     // upload
@@ -325,8 +337,20 @@ const upload = async (uploader, path, gasIncPct, threadPoolSize) => {
     const length = e.message.length;
     Logger.error(length > 500 ? (e.message.substring(0, 245) + " ... " + e.message.substring(length - 245, length)) : e.message);
     Logger.error(`Execution failed. Please check the error message and try again after making necessary adjustments.`);
+  } finally {
+    await safeClose(uploader);
   }
 };
+
+async function safeClose(instance) {
+  try {
+    if (instance && typeof instance.close === 'function') {
+      await instance.close();
+    }
+  } catch (error) {
+    Logger.error('Error while closing resource:', error);
+  }
+}
 // **** internal function ****
 
 module.exports.upload = estimateAndUpload;

--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,6 @@ const estimateAndUpload = async (key, domain, path, type, rpc, chainId, gasIncPc
   // query total cost
   const uploader = await Uploader.create(key, handler.providerUrl, handler.chainId, handler.address, type);
   if (!uploader) {
-    Logger.error("Failed to initialize SDK. Check parameters and network and try again.");
     return;
   }
 

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -19,7 +19,7 @@ class Logger {
     }
 
     static success(message) {
-        console.log(successColor(`✅  SUCCESS:   ${message}`));
+        console.log(successColor(`✅  FINISH:    ${message}`));
     }
 
     static log(message) {

--- a/src/utils/uploader.js
+++ b/src/utils/uploader.js
@@ -221,6 +221,12 @@ class Uploader {
             totalStorageCost: totalStorageCost,
         };
     }
+
+    async close() {
+        if(this.#flatDirectory) {
+            await this.#flatDirectory.close();
+        }
+    }
 }
 
 module.exports = {

--- a/test/test.js
+++ b/test/test.js
@@ -136,15 +136,43 @@ const runTests = async () => {
     // Prepare
     const largeFileName = "tempLargeFile.txt";
     const largeFile = path.resolve(__dirname, largeFileName);
-    createLargeFile(3, largeFile); // 6MB
+    createLargeFile(15, largeFile); // 15MB
     const folderPath = path.resolve(__dirname, 'randomFiles');
-    createFiles(13, folderPath);
-    const largeFileHash = await getFileHash(largeFile);
+    createFiles(13, folderPath); // 13 files
+
+    // quark chain
+    console.log("Running tests for QuarkChain L2 Network...");
+    const qkcChainId = 3335;
+    let address = await createContract(qkcChainId);
+    await setDefaultFile(address, qkcChainId);
+
+    await uploadFile(address, qkcChainId, largeFile); // upload large file
+    await uploadFile(address, qkcChainId, largeFile); // upload again
+
+    await uploadFile(address, qkcChainId, folderPath); // upload files
+    await uploadFile(address, qkcChainId, folderPath); // upload files again
+
+    // download and check
+    let largeFileHash = await getFileHash(largeFile);
+    deleteFile(largeFile);
+    await downloadFile(address, qkcChainId, largeFileName);
+    let downloadFileHash = await getFileHash(largeFile);
+    console.log(`\n File integrity check: `, largeFileHash === downloadFileHash);
+
+    // clear
+    deleteFile(largeFile);
+    deleteFolder(folderPath);
+
+
+
 
     // sepolia
-    console.log("Running tests for Sepolia Network...");
-    let sepoliaChainId =  11155111;
-    let address = await createContract(sepoliaChainId);
+    console.log("\nRunning tests for Sepolia Network...");
+    createLargeFile(2.5, largeFile); // 2.5MB
+    createFiles(5, folderPath); // 5 files
+
+    const sepoliaChainId =  11155111;
+    address = await createContract(sepoliaChainId);
     await setDefaultFile(address, sepoliaChainId);
 
     await uploadFile(address, sepoliaChainId, largeFile); // upload large file
@@ -155,31 +183,11 @@ const runTests = async () => {
 
     // TODO not support op blob
     // download and check
+    // largeFileHash = await getFileHash(largeFile);
     // deleteFile(largeFile);
     // await downloadFile(address, sepoliaChainId, largeFileName);
-    // let downloadFileHash = await getFileHash(largeFile);
+    // downloadFileHash = await getFileHash(largeFile);
     // console.log(`\n File integrity check: `, largeFileHash === downloadFileHash);
-
-
-
-    // quarkchain
-    console.log("\nRunning tests for QuarkChain L2 Network...");
-    const qkcChainId = 3335;
-    createLargeFile(15, largeFile);
-    address = await createContract(qkcChainId);
-    await setDefaultFile(address, qkcChainId);
-
-    await uploadFile(address, qkcChainId, largeFile); // upload large file
-    await uploadFile(address, qkcChainId, largeFile); // upload again
-
-    await uploadFile(address, qkcChainId, folderPath); // upload files
-    await uploadFile(address, qkcChainId, folderPath); // upload files again
-
-    // download and check
-    deleteFile(largeFile);
-    await downloadFile(address, qkcChainId, largeFileName);
-    let downloadFileHash = await getFileHash(largeFile);
-    console.log(`\n File integrity check: `, largeFileHash === downloadFileHash);
 
     // clear
     deleteFile(largeFile);

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,188 @@
+const { exec, spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const dotenv = require("dotenv")
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
+const privateKey = process.env.pk;
+
+const testCommandExec = (command, callback) => {
+    console.log(`Running command: ${command}`);
+    exec(command, (error, stdout, stderr) => {
+        if (error) {
+            console.error(`exec error: ${error}`);
+            callback(null);
+            return;
+        }
+        if (stderr) {
+            console.error(`stderr: ${stderr}`);
+            callback(null);
+            return;
+        }
+        console.log(stdout);
+        callback(stdout);
+    });
+}
+
+const testCommandSpawn = (command, args) => {
+    return new Promise((resolve, reject) => {
+        console.log(` \nRunning command: ${command} ${args.join(' ')}`);
+        const process = spawn(command, args, { shell: true });
+        process.stdout.on('data', (data) => {
+            console.log(data.toString().replace(/\n$/, ''));
+        });
+        process.stderr.on('data', (data) => {
+            console.error(`stderr: ${data.toString()}`);
+        });
+        process.on('close', (code) => {
+            if (code !== 0) {
+                reject(new Error(`Process exited with code ${code}`));
+                return;
+            }
+            resolve(true);
+        });
+    });
+};
+
+const createLargeFile = (sizeInMB, filePath) => {
+    const sizeInBytes = sizeInMB * 1024 * 1024;
+    const buffer = Buffer.alloc(sizeInBytes, 'A');
+    fs.writeFileSync(filePath, buffer);
+};
+
+const createFiles = (numFiles, folderPath) => {
+    try {
+        if (!fs.existsSync(folderPath)) {
+            fs.mkdirSync(folderPath, { recursive: true });
+        }
+
+        for (let i = 1; i <= numFiles; i++) {
+            const filePath = path.join(folderPath, `file_${i}.txt`);
+            const fileSize = Math.floor(Math.random() * (256 * 1024 - 2 * 1024) + 2 * 1024); // 2KB - 256MB
+            const content = i.toString().repeat(fileSize);
+            fs.writeFileSync(filePath, content);
+        }
+    } catch (err) {
+        console.error('Error creating files:', err);
+    }
+};
+
+const deleteFile = (filePath) => {
+    fs.unlinkSync(filePath);
+};
+
+const deleteFolder = (folderPath) => {
+    const files = fs.readdirSync(folderPath);
+    files.forEach(file => {
+        const currentPath = path.join(folderPath, file);
+        if (fs.statSync(currentPath).isDirectory()) {
+            deleteFolder(currentPath);
+        } else {
+            deleteFile(currentPath);
+        }
+    });
+    fs.rmdirSync(folderPath);
+};
+
+const getFileHash = (filePath) => {
+    return new Promise((resolve, reject) => {
+        const hash = crypto.createHash('sha256');
+        const stream = fs.createReadStream(filePath);
+        stream.on('data', (data) => {
+            hash.update(data);
+        });
+        stream.on('end', () => {
+            resolve(hash.digest('hex'));
+        });
+        stream.on('error', (err) => {
+            reject(err);
+        });
+    });
+};
+
+// api
+const createContract = (chainId) => {
+    return new Promise((resolve, reject) => {
+        const command = `node ../cli.js create -p ${privateKey} -c ${chainId}`;
+        testCommandExec(command, (output) => {
+            const match = output.match(/FlatDirectory: Address is (\b0x[a-fA-F0-9]{40}\b)/);
+            const contractAddress = match ? match[1] : null;
+            if (contractAddress) {
+                resolve(contractAddress);
+            } else {
+                reject(new Error('Contract address extraction failed.'));
+            }
+        });
+    });
+};
+
+const setDefaultFile = async (address, chainId) => {
+    const args = ['../cli.js', 'default', '-p', privateKey, '-a', address, '-c', chainId];
+    return await testCommandSpawn('node', args);
+};
+
+const uploadFile = async (address, chainId, tempFilePath) => {
+    const args = ['../cli.js', 'upload', '-p', privateKey, '-a', address, '-f', tempFilePath, '-c', chainId];
+    return await testCommandSpawn('node', args);
+};
+
+const downloadFile = async (address, chainId, largeFile) => {
+    const args = ['../cli.js', 'download', '-a', address, '-f', largeFile, '-c', chainId];
+    return await testCommandSpawn('node', args);
+};
+
+const runTests = async () => {
+    // Prepare
+    const largeFileName = "tempLargeFile.txt";
+    const largeFile = path.resolve(__dirname, largeFileName);
+    createLargeFile(3, largeFile); // 6MB
+    const folderPath = path.resolve(__dirname, 'randomFiles');
+    createFiles(13, folderPath);
+    const largeFileHash = await getFileHash(largeFile);
+
+    // sepolia
+    console.log("Running tests for Sepolia Network...");
+    let sepoliaChainId =  11155111;
+    let address = await createContract(sepoliaChainId);
+    await setDefaultFile(address, sepoliaChainId);
+
+    await uploadFile(address, sepoliaChainId, largeFile); // upload large file
+    await uploadFile(address, sepoliaChainId, largeFile); // upload again
+
+    await uploadFile(address, sepoliaChainId, folderPath);
+    await uploadFile(address, sepoliaChainId, folderPath);
+
+    // TODO not support op blob
+    // download and check
+    // deleteFile(largeFile);
+    // await downloadFile(address, sepoliaChainId, largeFileName);
+    // let downloadFileHash = await getFileHash(largeFile);
+    // console.log(`\n File integrity check: `, largeFileHash === downloadFileHash);
+
+
+
+    // quarkchain
+    console.log("\nRunning tests for QuarkChain L2 Network...");
+    const qkcChainId = 3335;
+    createLargeFile(15, largeFile);
+    address = await createContract(qkcChainId);
+    await setDefaultFile(address, qkcChainId);
+
+    await uploadFile(address, qkcChainId, largeFile); // upload large file
+    await uploadFile(address, qkcChainId, largeFile); // upload again
+
+    await uploadFile(address, qkcChainId, folderPath); // upload files
+    await uploadFile(address, qkcChainId, folderPath); // upload files again
+
+    // download and check
+    deleteFile(largeFile);
+    await downloadFile(address, qkcChainId, largeFileName);
+    let downloadFileHash = await getFileHash(largeFile);
+    console.log(`\n File integrity check: `, largeFileHash === downloadFileHash);
+
+    // clear
+    deleteFile(largeFile);
+    deleteFolder(folderPath);
+};
+runTests();

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,10 +150,10 @@ ethers@^6.13.1:
     tslib "2.4.0"
     ws "8.17.1"
 
-ethstorage-sdk@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.npmjs.org/ethstorage-sdk/-/ethstorage-sdk-2.1.5.tgz#7cf141029a9f34cd095522cf2f0c1744dae47e12"
-  integrity sha512-o75ccnQF9SOtSnNsw7l+683IqOEl0e0LEcZtuqZog8dlbfcsfE5XYGdzT1zEBOdbkNW1dU2ySbtf5unRBB/Mpg==
+ethstorage-sdk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/ethstorage-sdk/-/ethstorage-sdk-3.0.0.tgz#fc468b6cb8abb901c2bc05cbcf985cd78559f4e6"
+  integrity sha512-qCoAd5WPU52iRSLuvxCrnVz0H2o0AW2T3vi5JWTx8fKqNFFpKbco0E9Tsr6CywLJ0xFEbY+WX5w5LAFHoElsVw==
   dependencies:
     async-mutex "^0.5.0"
     dotenv "^16.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,6 +129,11 @@ dotenv@^16.4.5:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
 
+dotenv@^16.4.7:
+  version "16.4.7"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
+  integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
+
 eth-ens-namehash@^2.0.8:
   version "2.0.8"
   resolved "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz#229ac46eca86d52e0c991e7cb2aef83ff0f68bcf"


### PR DESCRIPTION
This PR ensures that the `FlatDirectory.close()` method is called after the task execution is completed. The new version of the ethstorage-sdk introduces a thread pool, which is initialized in the constructor and remains active throughout the instance's lifecycle. To avoid resource leaks or excessive system resource usage, it is crucial to release the thread pool once the task is finished.